### PR TITLE
Specify Node version requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 # Meus
 /diversos
 /temp
+# Ignore all dotfiles except for .nvmrc
 .*
+!.nvmrc
 
 # Compiled output
 /dist

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,2 @@
+# Versão do Node recomendada para este projeto
+18

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 2. Adicione sua própria chave da API OpenAI ao arquivo `.env`
 3. Execute `npm run setup` para gerar os arquivos de ambiente
 4. Nunca comite arquivos `.env` ou `environment.ts`
+5. Certifique-se de usar a versão 18 do Node.js conforme definido em `.nvmrc`
+<!-- Adicionada instrução sobre a versão do Node -->
 
 ## Further help
 


### PR DESCRIPTION
## Summary
- allow `.nvmrc` to be committed
- add `.nvmrc` with Node 18
- document Node version requirement in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684322bb93b4832d9f8bda4b59feedd1