### PR TITLE
Fix missing dotenv dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/papaparse": "^5.3.15",
         "@types/qrcode": "^1.5.5",
         "@types/xlsx": "^0.0.35",
+        "dotenv": "^16.5.0",
         "dotenv-webpack": "^8.1.0",
         "jasmine-core": "~5.2.0",
         "karma": "~6.4.0",
@@ -8158,6 +8159,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-defaults": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/papaparse": "^5.3.15",
     "@types/qrcode": "^1.5.5",
     "@types/xlsx": "^0.0.35",
+    "dotenv": "^16.5.0",
     "dotenv-webpack": "^8.1.0",
     "jasmine-core": "~5.2.0",
     "karma": "~6.4.0",


### PR DESCRIPTION
## Summary
- include `dotenv` in devDependencies
- update `package-lock.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68430f4b299c832d94f5c9b71a35c74d