### PR TITLE
Add typings and update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+Run `npm install` to install dependencies and `npm run setup` to generate
+`environment.ts` before building. After that, run `ng build` to build the
+project. The build artifacts will be stored in the `dist/` directory.
 
 ## Running unit tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@angular/cli": "^18.2.11",
         "@angular/compiler-cli": "^18.2.11",
         "@types/jasmine": "~5.1.0",
+        "@types/node": "^22.15.30",
         "@types/papaparse": "^5.3.15",
         "@types/qrcode": "^1.5.5",
         "@types/xlsx": "^0.0.35",
@@ -5549,12 +5550,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -15824,9 +15825,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@angular/cli": "^18.2.11",
     "@angular/compiler-cli": "^18.2.11",
     "@types/jasmine": "~5.1.0",
+    "@types/node": "^22.15.30",
     "@types/papaparse": "^5.3.15",
     "@types/qrcode": "^1.5.5",
     "@types/xlsx": "^0.0.35",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 // Alteração: remoção de logs de depuração (console.log)
 import { Component, OnInit } from '@angular/core';
-import { RouterOutlet, Router, NavigationEnd } from '@angular/router';
+import { RouterOutlet, Router, NavigationEnd, Event as RouterEvent } from '@angular/router';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { UserService } from './shared/services/user.service';
 import { AngularFireAuth } from '@angular/fire/compat/auth';
@@ -34,7 +34,8 @@ export class AppComponent implements OnInit {
     private afAuth: AngularFireAuth // Adicionar AngularFireAuth
   ) {
     this.router.events.subscribe({
-      next: (event) => {
+      next: (event: RouterEvent) => {
+        // Alteração: tipagem explícita do parâmetro event
         // Your navigation handling code
       },
       error: (err) => {

--- a/src/app/shared/services/form.service.ts
+++ b/src/app/shared/services/form.service.ts
@@ -365,23 +365,25 @@ export class FormService {
     }
 
     /**
-     * onFieldChange(event: any, campoNome: string): void
+     * onFieldChange(event: Event, campoNome: string): void // Alteração: tipagem explícita do parâmetro event
      * 
      * Parâmetros:
-     * - event: any - Evento de mudança de valor no campo.
+     * - event: Event - Evento de mudança de valor no campo. // Alteração: atualizado tipo na documentação
      * - campoNome: string - Nome do campo.
      * Funcionalidade:
      * - Processa a mudança de valor em um campo do formulário.
      * - Aplica transformações (como capitalização) e atualiza o controle.
      * Retorna: void.
      */
-    onFieldChange(event: any, campoNome: string): void {
-        if (event.target && event.target.type === 'checkbox') {
-            this.fichaForm.get(campoNome)?.setValue(event.target.checked);
+    onFieldChange(event: Event, campoNome: string): void {
+        // Alteração: tipagem explícita do parâmetro event
+        const target = event.target as HTMLInputElement | null; // Cast para acessar propriedades de input
+        if (target && target.type === 'checkbox') {
+            this.fichaForm.get(campoNome)?.setValue(target.checked);
             return;
         }
-        if (this.fichaForm && this.fichaForm.get(campoNome)) {
-            const valorAtual = event.target.value;
+        if (this.fichaForm && this.fichaForm.get(campoNome) && target) {
+            const valorAtual = target.value;
 
             // Não aplicar capitalização para o campo email
             if (campoNome === 'email') {

--- a/src/app/tutfop/tutfop.component.ts
+++ b/src/app/tutfop/tutfop.component.ts
@@ -226,7 +226,8 @@ export class TutfopComponent implements OnInit, OnDestroy {
   private setupEventListeners(): void {
     const userInput = document.getElementById("tutfop-user-input") as HTMLTextAreaElement;
     if (userInput) {
-      userInput.addEventListener("keypress", (event) => {
+      userInput.addEventListener("keypress", (event: KeyboardEvent) => {
+        // Alteração: tipagem explícita do parâmetro event
         if (event.key === "Enter" && !event.shiftKey) {
           event.preventDefault();
           this.sendTutfopMessage();

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -288,10 +288,12 @@ export class ViewComponent implements OnInit, OnDestroy {
   }
 
   // Método auxiliar para formatação de datas em histórico
-  formatDate(timestamp: any): string {
+  formatDate(timestamp: firebase.firestore.Timestamp | Date | number): string {
+    // Alteração: tipagem explícita do parâmetro timestamp
     if (!timestamp) return 'Data desconhecida';
 
-    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
+    const ts: any = timestamp; // Cast para permitir chamada de toDate()
+    const date = ts.toDate ? ts.toDate() : new Date(ts);
     return date.toLocaleDateString('pt-BR') + ' ' + date.toLocaleTimeString('pt-BR');
   }
 
@@ -349,7 +351,8 @@ export class ViewComponent implements OnInit, OnDestroy {
   }
 
   // Agrupa campos pelo atributo "grupo"
-  groupByGrupo(campos: any[]): { [key: string]: any[] } {
+  groupByGrupo(campos: Array<{ grupo?: string }>): { [key: string]: any[] } {
+    // Alteração: tipagem explícita do parâmetro campos
     return campos.reduce((groups, campo) => {
       const grupo = campo.grupo || 'Sem Agrupamento';
       if (!groups[grupo]) {
@@ -361,7 +364,8 @@ export class ViewComponent implements OnInit, OnDestroy {
   }
 
   // Group campos by their subgrupo property
-  groupBySubgrupo(campos: any[]): { [key: string]: any[] } {
+  groupBySubgrupo(campos: Array<{ subgrupo?: string }>): { [key: string]: any[] } {
+    // Alteração: tipagem explícita do parâmetro campos
     return campos.reduce((subgroups, campo) => {
       const subgrupo = campo.subgrupo || '';
       if (!subgroups[subgrupo]) {
@@ -377,7 +381,8 @@ export class ViewComponent implements OnInit, OnDestroy {
     return item.key;
   }
 
-  trackByCampo(index: number, campo: any): string {
+  trackByCampo(index: number, campo: { nome: string }): string {
+    // Alteração: tipagem explícita do parâmetro campo
     return campo.nome;
   }
 
@@ -524,7 +529,8 @@ export class ViewComponent implements OnInit, OnDestroy {
    * Considera como vazios: null, undefined, string vazia, 0 (número), '0' (string)
    * Para campos booleanos/checkbox, só considera não vazio se for true
    */
-  hasNonEmptyField(campos: any[]): boolean {
+  hasNonEmptyField(campos: Array<{ nome: string; tipo: string }>): boolean {
+    // Alteração: tipagem explícita do parâmetro campos
     if (!campos || campos.length === 0) return false;
 
     return campos.some(campo => {


### PR DESCRIPTION
## Summary
- install `@types/node` as dev dependency
- document running `npm install` and `npm run setup` before `ng build`
- explicitly type event handlers and helper params

## Testing
- `npm run build` *(fails: Inlining of fonts failed)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: not all code paths return a value)*

------
https://chatgpt.com/codex/tasks/task_e_68439f0e5794832d9c80eee1a4853374