### PR TITLE
Fix Firestore cleanup on logout

### DIFF
--- a/src/app/shared/services/user.service.ts
+++ b/src/app/shared/services/user.service.ts
@@ -499,6 +499,14 @@ private initializeService(): void {
   // Método para limpar os dados do usuário no logout
   async logout(): Promise<void> {
     try {
+      // Alteração: desativar rede do Firestore e encerrar conexões antes do logout
+      try {
+        await this.firestore.firestore.disableNetwork();
+        await this.firestore.firestore.terminate(); // encerra todas as conexões pendentes
+      } catch (e) {
+        console.error('Erro ao desativar a rede do Firestore:', e);
+      }
+
       // Limpar dados de autenticação
       await this.afAuth.signOut();
       


### PR DESCRIPTION
## Summary
- disable Firestore network and terminate listeners when logging out

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6843a5558040832dbc81dce9ee1110cc